### PR TITLE
Add chain() and before() to rapier system setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,9 @@ fn main() {
                     .in_set(PhysicsSet::StepSimulation),
                 RapierPhysicsPlugin::<NoUserData>::get_systems(PhysicsSet::Writeback)
                     .in_set(PhysicsSet::Writeback),
-            ),
+            )
+            .chain()
+            .before(TransformSystem::TransformPropagate),
         )
         .add_systems(Last, bevy_rapier3d::plugin::systems::sync_removals)
         .insert_resource(ClearColor(Color::BLACK))


### PR DESCRIPTION
I had some issues when a body was attached to the camera as a child (it would not move with the camera), but many other aspects of the simulation worked just fine.
After looking into rapier's plugin code, I found [this](https://github.com/dimforge/bevy_rapier/blob/a4e9343cd75ce2be788280de2c21ed7efb9039b7/src/plugin/plugin.rs#L299C1-L308C15)
Using `chain()` and `before()` just like in rapier's code solved my issue.
The docs also mention [StepSimulation typically runs immediately after PhysicsSet::SyncBackend](https://docs.rs/bevy_rapier3d/latest/bevy_rapier3d/plugin/enum.PhysicsSet.html)